### PR TITLE
Switch to Github's runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   release:
-    runs-on: [self-hosted, Ubuntu-20.04]
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, Ubuntu-20.04]
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Since the repo is public, we switch over to GH's runners for now.